### PR TITLE
SD - Prompt EasyMaker v3β-7

### DIFF
--- a/Scripts/prax_config_bind_sync/lib.py
+++ b/Scripts/prax_config_bind_sync/lib.py
@@ -1,0 +1,31 @@
+
+def get_binds(basic_data_dict):
+  binds4module = []
+  
+  for x in basic_data_dict["modules"]:
+    bind = x["keybind"]
+    print("Detected keybind for {x['name']} key: {x['keybind']}")
+    
+    if bind != 0:
+      binds4module.append(bind)
+    else:
+      binds4module.append(None)
+  return binds4module
+
+def get_module_index_from_name(name, target_config):
+  for index, data in enumerate(target_config["modules"]):
+    if data["name"] == name:
+      return index
+
+def set_key_from_index(target_config, index, key)
+
+def reset_keybind(prv_config, db_config, replace, strict):
+  bind_list = get_binds(db_config)
+  newed_binds = get_binds(prv_config)
+  
+  for index, bind in enumerate(bind_list):
+    if strict:
+      if db_config["modules"][index]["name"] != prv_config["modules"][index]["name"]:
+        print("not matched module name in ", index, ".\nanalyzing correct module..", end="")
+        correctly_index = get_module_index_from_name(db_config["modules"][index]["name"], prv_config)
+        

--- a/Scripts/prax_config_bind_sync/pcbs.py
+++ b/Scripts/prax_config_bind_sync/pcbs.py
@@ -1,0 +1,1 @@
+from lib import 


### PR DESCRIPTION
\+ Restore Deleted Prompt Template (ONLY deleted by WebUI)
\+ Multiple Delete / Restore Prompt Template
\+ Define Lora Template in WebUI
\+ Delete Lora Template in WebUI
\+ Multiple Delete Lora Template
\+ Template Generate are now Save all output Prompt
\+ Load Lora Template and input to Define tabs
\* Fix Prompt Template's Example System are not shown on Generate Tab [(#7)](https://github.com/luna724/luna_py/issues/7)
\* Catch "don't use character lora" Error [(#7)](https://github.com/luna724/luna_py/issues/7)
\* Database tab values can now be changed
\* [launch.py]'s new argument